### PR TITLE
Added set site command, Added utils and Refactored code

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/loginradius/lr-cli/request"
+)
+
+type SitesToken struct {
+	APIVersion    string `json:"ApiVersion"`
+	AppID         int32  `json:"AppId"`
+	AppName       string `json:"AppName"`
+	Authenticated bool   `json:"authenticated"`
+	XSign         string `json:"xsign"`
+	XToken        string `json:"xtoken"`
+}
+
+func SetSites(appid int) (*SitesToken, error) {
+	switchapp := conf.AdminConsoleAPIDomain + "/account/switchapp?appid=" + strconv.Itoa(appid)
+	switchResp, err := request.Rest(http.MethodGet, switchapp, nil, "")
+	var switchRespObj SitesToken
+	err = json.Unmarshal(switchResp, &switchRespObj)
+	if err != nil {
+		return nil, err
+	}
+	return &switchRespObj, nil
+}

--- a/api/auth.go
+++ b/api/auth.go
@@ -2,9 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"time"
 
+	"github.com/loginradius/lr-cli/cmdutil"
 	"github.com/loginradius/lr-cli/config"
 	"github.com/loginradius/lr-cli/request"
 )
@@ -61,4 +65,75 @@ func AuthValidateToken() (*ValidateTokenResp, error) {
 		return nil, err
 	}
 	return &resObj, nil
+}
+
+type AppID struct {
+	CurrentAppId int `json:"currentAppId"`
+}
+
+func CurrentID() (*AppID, error) {
+	conf := config.GetInstance()
+	config := conf.AdminConsoleAPIDomain + "/auth/config?"
+	var currentAppId AppID
+	resp, err := request.Rest(http.MethodGet, config, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(resp, &currentAppId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &currentAppId, nil
+}
+
+func SitesBasic(tokens *SitesToken) error {
+	conf := config.GetInstance()
+	var newToken SitesToken
+	client := &http.Client{}
+	basic := conf.AdminConsoleAPIDomain + "/auth/basicsettings?"
+	req, err := http.NewRequest(http.MethodGet, basic, nil)
+	if err != nil {
+		log.Printf("Could not make request % -v", err)
+	}
+	req.Header.Add("x-is-loginradius--sign", tokens.XSign)
+	req.Header.Add("x-is-loginradius--token", tokens.XToken)
+	req.Header.Add("x-is-loginradius-ajax", "true")
+	req.Header.Add("Content-Type", "application/json; charset=utf-8")
+	req.Header.Add("Origin", conf.DashboardDomain)
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("%s", err.Error())
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Print(err.Error())
+	}
+	//obtaining the new tokens
+	err = json.Unmarshal(bodyBytes, &newToken)
+	if err != nil {
+		return err
+	}
+	result := LoginResponse{
+		APIVersion:    tokens.APIVersion,
+		AppName:       tokens.AppName,
+		AppID:         tokens.AppID,
+		Authenticated: true,
+		XSign:         newToken.XSign, //switching tokens
+		XToken:        newToken.XToken,
+	}
+	resObj, err := json.Marshal(result)
+	err = cmdutil.DeleteFiles()
+	if err != nil {
+		return err
+	}
+	err = cmdutil.StoreCreds(resObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
 }

--- a/api/deployment.go
+++ b/api/deployment.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+
 	"net/http"
 	"time"
 
@@ -142,4 +143,19 @@ func AppInfo() (*CoreAppData, error) {
 		return nil, err
 	}
 	return &App, nil
+}
+
+func CheckApp(appid int) (bool, error) {
+	AppInfo, err := AppInfo()
+	if err != nil {
+		return false, err
+	}
+	numberOfApps := len(AppInfo.Apps.Data)
+	for i := 0; i < numberOfApps; i++ {
+		if appid == AppInfo.Apps.Data[i].Appid {
+			return true, nil
+		}
+	}
+	return false, nil
+
 }

--- a/cmd/get/site/site.go
+++ b/cmd/get/site/site.go
@@ -1,20 +1,12 @@
 package site
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/loginradius/lr-cli/api"
-	"github.com/loginradius/lr-cli/config"
-	"github.com/loginradius/lr-cli/request"
 	"github.com/spf13/cobra"
 )
-
-type AppID struct {
-	CurrentAppId int `json:"currentAppId"`
-}
 
 var all *bool
 var active *bool
@@ -63,7 +55,7 @@ func getSite() error {
 	numberOfApps := len(AppInfo.Apps.Data)
 
 	if *active && (!*all && *appid == -1) {
-		currentID, err := currentID()
+		currentID, err := api.CurrentID()
 		if err != nil {
 			return err
 		}
@@ -103,23 +95,6 @@ func getSite() error {
 	}
 
 	return nil
-}
-
-func currentID() (*AppID, error) {
-	conf := config.GetInstance()
-	config := conf.AdminConsoleAPIDomain + "/auth/config?"
-	var currentAppId AppID
-	resp, err := request.Rest(http.MethodGet, config, nil, "")
-	if err != nil {
-		return nil, err
-	}
-	err = json.Unmarshal(resp, &currentAppId)
-	if err != nil {
-		return nil, err
-	}
-
-	return &currentAppId, nil
-
 }
 
 func Output(AppInfo *api.CoreAppData, i int) {

--- a/cmd/logout/logout.go
+++ b/cmd/logout/logout.go
@@ -2,12 +2,10 @@ package logout
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -36,7 +34,7 @@ func logout() error {
 	dirName := filepath.Join(user.HomeDir, ".lrcli")
 	_, err := os.Stat(dirName)
 	if os.IsNotExist(err) {
-		fmt.Println("You are already been logged out")
+		fmt.Println("You have already been logged out")
 		return nil
 	} else {
 		cmdutil.Openbrowser(conf.HubPageDomain + "/auth.aspx?action=logout&return_url=http://localhost:8089/postLogout")
@@ -46,10 +44,7 @@ func logout() error {
 			RouteName:   "/postLogout",
 		})
 		tempServer.Server.ListenAndServe()
-		dir, err := ioutil.ReadDir(dirName)
-		for _, d := range dir {
-			os.RemoveAll(path.Join([]string{dirName, d.Name()}...))
-		}
+		err := cmdutil.DeleteFiles()
 		if err != nil {
 			return err
 		}

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -4,6 +4,7 @@ import (
 	"github.com/loginradius/lr-cli/cmd/set/accountPassword"
 	"github.com/loginradius/lr-cli/cmd/set/domain"
 	"github.com/loginradius/lr-cli/cmd/set/email"
+	"github.com/loginradius/lr-cli/cmd/set/site"
 	"github.com/loginradius/lr-cli/cmd/set/theme"
 
 	"github.com/spf13/cobra"
@@ -16,6 +17,9 @@ func NewsetCmd() *cobra.Command {
 		Short: "set command",
 		Long:  `This commmand acts as a base command for set subcommands`,
 	}
+
+	siteCmd := site.NewSiteCmd()
+	cmd.AddCommand(siteCmd)
 
 	themeCmd := theme.NewThemeCmd()
 	cmd.AddCommand(themeCmd)

--- a/cmd/set/site/site.go
+++ b/cmd/set/site/site.go
@@ -1,0 +1,62 @@
+package site
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/loginradius/lr-cli/api"
+	"github.com/spf13/cobra"
+)
+
+var appid int
+
+func NewSiteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "site",
+		Short: "Enables switching between sites",
+		Long: heredoc.Doc(`
+		This command changes switches sites based on the App ID entered by the user.
+		`),
+		Example: heredoc.Doc(`
+			$ lr set site --appid <appid>  # To fetch app id use  lr get site --all
+
+			Your site has been changed
+			
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setSite()
+		},
+	}
+	fl := cmd.Flags()
+	fl.IntVarP(&appid, "appid", "i", -1, "Switches the site")
+
+	return cmd
+}
+
+func setSite() error {
+	checkApp, err := api.CheckApp(appid)
+	if err != nil {
+		return err
+	}
+	if !checkApp {
+		fmt.Println("There is no site with this AppID.")
+		return nil
+	}
+	currentID, err := api.CurrentID()
+	if err != nil {
+		return err
+	}
+	if currentID.CurrentAppId == appid {
+		fmt.Println("You are already using this site")
+		return nil
+	}
+	switchRespObj, err := api.SetSites(appid)
+	err = api.SitesBasic(switchRespObj)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Your site has been changed")
+
+	return nil
+}

--- a/cmdutil/lrUtils.go
+++ b/cmdutil/lrUtils.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"path"
 	"path/filepath"
 	"runtime"
 )
@@ -107,4 +108,17 @@ func ThemeConstants(theme string) (ThemeType, ThemeType) {
 		"Helsinki": Theme3Profile,
 	}
 	return auths[theme], profiles[theme]
+}
+
+func DeleteFiles() error {
+	user, _ := user.Current()
+	dirName := filepath.Join(user.HomeDir, ".lrcli")
+	dir, err := ioutil.ReadDir(dirName)
+	for _, d := range dir {
+		os.RemoveAll(path.Join([]string{dirName, d.Name()}...))
+	}
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

#### Please note that in case of below checklist not updated accordingly, the maintainers have the right to immediately close your pull request.

- [x] You created a branch from `develop` branch.
- [x] You PR is raised on `develop` branch and not on`main`.
- [x] You have read the [Contribution Guidlines](CONTRIBUTING.md) before creating this PR.

### Description of the Change

- Added `lr set site --appid` command which allows users to switch between sites. The token values (xtoken ans xsign) and app details are updated in the `tokens.json` file when this command is ran. 
- Created `api/account.go` which will contain functions that handle API calls to account API's. Currently added functionality here for **set site** command.
- Added function in `lrUtils.go` to delete files in `.lrcli` folder. This is to support common functionality in `logout` and `set site` commands. 
- Added `SitesBasic()` function in **api/auth.go**  to support site command related API calls.  

### Risk Impact

- High. (Token values change when we switch sites.)

### Verification Process

- Tested following commands multiple times for accounts with multiple sites:
```
- lr set site --appid <appid>

Ran these command after above command to check if new tokens are working
- lr get config
- lr get site --active
- lr get theme --active
- lr get domain
```
### Release Notes

- Added the `lr set site --appid` command. 
- Added utils, functionality and refactored code for site and logout commands.